### PR TITLE
Updated dependency-tree to remove Go

### DIFF
--- a/_projects/dependency-tree-metric-aggregation.md
+++ b/_projects/dependency-tree-metric-aggregation.md
@@ -22,9 +22,9 @@ link: false
 ---
 The goal of this research is to aid developers and software architects in making good component choices through an analysis of the relevance and utility of security measures from the entire dependency tree associated with a package.
 
-The survey for GO developers is LIVE! And can be found at: [https://ncsu.qualtrics.com/jfe/form/SV_elWM15q0URJEr8q](https://ncsu.qualtrics.com/jfe/form/SV_elWM15q0URJEr8q)
+<!-- The survey for NPM developers is LIVE! And can be found at: [https://ncsu.qualtrics.com/jfe/form/SV_elWM15q0URJEr8q](https://ncsu.qualtrics.com/jfe/form/SV_elWM15q0URJEr8q) -->
 
-If possible, please fill out the survey *no later than July 19*.
+If possible, please fill out the survey *no later than July 4.
 
 # Survey Overview
 

--- a/_projects/dependency-tree-metric-aggregation.md
+++ b/_projects/dependency-tree-metric-aggregation.md
@@ -22,7 +22,7 @@ link: false
 ---
 The goal of this research is to aid developers and software architects in making good component choices through an analysis of the relevance and utility of security measures from the entire dependency tree associated with a package.
 
-<!-- The survey for NPM developers is LIVE! And can be found at: [https://ncsu.qualtrics.com/jfe/form/SV_elWM15q0URJEr8q](https://ncsu.qualtrics.com/jfe/form/SV_elWM15q0URJEr8q) -->
+The survey for NPM developers is LIVE! And can be found at: [https://ncsu.qualtrics.com/jfe/form/SV_0UPtFnYI3vISiG2](https://ncsu.qualtrics.com/jfe/form/SV_0UPtFnYI3vISiG2)
 
 If possible, please fill out the survey *no later than July 4.
 


### PR DESCRIPTION
Updated dependency-tree-metric project to remove go in anticipation of deploying NPM

Anticipate one more addition (tomorrow?) with the url for the qualtrics survey